### PR TITLE
feat(require): add support for browserify.require and options.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+  </body>
+</html>
+

--- a/index.js
+++ b/index.js
@@ -36,15 +36,7 @@ const outputCoverage = (page) => {
   })
 }
 
-const index = `
-<!DOCTYPE html>
-  <head>
-    <meta charset="UTF-8">
-  </head>
-  <body>
-  </body>
-</html>
-`
+const index = path.join(__dirname, 'index.html')
 
 /* istanbul ignore next */
 module.exports = (entryPoint, opts = {}) => {
@@ -77,11 +69,12 @@ module.exports = (entryPoint, opts = {}) => {
     return test(name, async t => {
       const _browser = await browser
       const page = await _browser.newPage()
-      if (opts.location) {
-        await page.goto(opts.location)
-      } else {
-        await page.setContent(index)
-      }
+
+      // we use a file url here so that the default page gets loaded in a secure context.
+      // required to test apis like https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto
+      // http://www.chromium.org/Home/chromium-security/security-faq#TOC-Which-origins-are-secure-
+
+      await page.goto(opts.location || 'file://' + index)
 
       /* istanbul ignore next */
       page.on('console', msg => console.log(msg.text()))

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const index = `
 
 /* istanbul ignore next */
 module.exports = (entryPoint, opts = {}) => {
-  const browser = puppeteer.launch({args: ['--no-sandbox']})//, headless: false})
+  const browser = puppeteer.launch({args: ['--no-sandbox']})
 
   const bundle = new Promise((resolve, reject) => {
     var b = browserify()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@soldair/cappadonna",
-  "version": "1.3.1",
+  "name": "cappadonna",
+  "version": "0.0.0-development",
   "description": "Headless browser testing for tap with coverage reporting.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cappadonna",
-  "version": "0.0.0-development",
+  "name": "@soldair/cappadonna",
+  "version": "1.3.1",
   "description": "Headless browser testing for tap with coverage reporting.",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "bl": "^1.2.1",
     "browserify": "^15.0.0",
     "browserify-istanbul": "^3.0.1",
-    "puppeteer": "^1.0.0",
+    "puppeteer": "^1.2.0",
     "tap": "^11.1.0"
   },
   "repository": {

--- a/tests/module.js
+++ b/tests/module.js
@@ -1,0 +1,2 @@
+
+module.exports = 'pass'

--- a/tests/test-basics.js
+++ b/tests/test-basics.js
@@ -21,9 +21,10 @@ test('basics', async (page, t) => {
 })
 
 test('appendAndWait', async (page, t) => {
-  t.plan(1)
+  t.plan(2)
   await page.appendAndWait('<test-me>pass</test-me>', 'test-me')
   await page.evaluate(async () => {
+    t.ok(window.isSecureContext, 'load default page from file url so we have a secure context')
     t.same('pass', document.querySelector('test-me').textContent)
   })
 })

--- a/tests/test-require.js
+++ b/tests/test-require.js
@@ -1,0 +1,21 @@
+const path = require('path')
+const cappadonna = require('../')
+
+const opts = {
+  ignore: ['**/node_modules/**', '**/bower_components/**', '**/*.json'],
+  include: [path.join(__dirname, '..', 'index.js'), '**/tests/**'],
+  defaultIgnore: false
+}
+
+const aModule = path.join(__dirname, 'module.js')
+const test = cappadonna(aModule, {istanbul: opts, require: {expose: 'entry-module'}})
+
+test('can require', async (page, t) => {
+  t.plan(1)
+  console.log('i planned')
+  await page.evaluate(async () => {
+    console.log('im in the page')
+    t.equals(require('entry-module'), 'pass', 'should be able to require')
+    console.log('iasserted and should be done')
+  })
+})


### PR DESCRIPTION
this is nice because you can require the bundle in your tests just
as you expect folks to in your module.

this is a little weird because requires are not evaluated until you
require them for the first time which breaks the window.`__coverage__`
test. If you specify require i just test that the code has `__coverage__`
in it.

couple notes.
- im not sure the exception is super useful
- and when its thrown its really hard to debug because of error propagation. (in `npm test` everything just hangs stuck at that point)

this also has a fix for console.log within the page. the api .text is
actually a function so now we call it to get the message logged from the
page.